### PR TITLE
Add support for Deno Vite import transform

### DIFF
--- a/deno-vite-plus/index.ts
+++ b/deno-vite-plus/index.ts
@@ -11,6 +11,7 @@ import nodeExternals from 'npm:rollup-plugin-node-externals'
  * - Local Deno module imports
  * - SSR support for both development and production
  * - TypeScript/JSX transformation
+ * - Transform @deno-vite-import comments into actual imports
  */
 export default function fasterDeno(): Plugin[] {
   return [

--- a/deno-vite-plus/lib/deno-resolver.ts
+++ b/deno-vite-plus/lib/deno-resolver.ts
@@ -16,13 +16,11 @@ export class DenoResolver {
     for (const module of info.modules) {
       if ('error' in module || module.kind !== 'esm') {
         this.modules.set(module.specifier, module)
-        console.log('Added module', module.specifier)
         continue
       }
 
       const resolvedInfo = this.transformEsmModule(module, info.redirects)
       this.modules.set(module.specifier, resolvedInfo)
-      console.log('Added module', module.specifier)
     }
 
     const actualId = info.roots[0]
@@ -47,7 +45,10 @@ export class DenoResolver {
     }
   }
 
-  async resolve(id: string, importerSpecifier: string | null): Promise<string> {
+  async resolve(
+    id: string,
+    importerSpecifier: string | null,
+  ): Promise<string | null> {
     if (importerSpecifier !== null) {
       // With importer, id must be in the importer's dependencies
       const importerModule = this.modules.get(importerSpecifier)
@@ -68,9 +69,7 @@ export class DenoResolver {
         }
       }
 
-      throw new Error(
-        `Import "${id}" not found in dependencies of ${importerSpecifier}`,
-      )
+      return null
     } else {
       // Without importer, check cache first
       const cached = this.idToSpecifierCache.get(id)

--- a/deno-vite-plus/package.json
+++ b/deno-vite-plus/package.json
@@ -1,6 +1,12 @@
 {
   "type": "module",
   "dependencies": {
+    "@babel/parser": "^7.27.2",
+    "@babel/types": "^7.27.1",
+    "acorn": "^8.14.1",
+    "acorn-jsx": "^5.3.2",
+    "acorn-typescript": "^1.4.13",
+    "magic-string": "^0.30.17",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "rollup-plugin-node-externals": "^8.0.0",

--- a/deno-vite-plus/plugins/vite-load-hook.ts
+++ b/deno-vite-plus/plugins/vite-load-hook.ts
@@ -1,0 +1,150 @@
+// vite_load_hook.ts --------------------------------------------------------
+import { dirname as dir, resolve as resolvePath } from 'jsr:@std/path'
+import { type Loader, transform } from 'esbuild'
+import { parse as babelParse } from '@babel/parser'
+import MagicString from 'npm:magic-string'
+
+import type { DenoMediaType, ResolvedInfo } from '../lib/types.ts'
+
+export function mediaTypeToLoader(media: DenoMediaType): Loader {
+  switch (media) {
+    case 'JSX':
+      return 'jsx'
+    case 'JavaScript':
+      return 'js'
+    case 'Json':
+      return 'json'
+    case 'TSX':
+      return 'tsx'
+    case 'TypeScript':
+      return 'ts'
+  }
+}
+
+export async function loadAndRewrite(
+  moduleInfo: ResolvedInfo,
+): Promise<{ code: string; map: string | null }> {
+  /* 1️⃣  read the original text */
+  let source = await Deno.readTextFile(moduleInfo.local)
+
+  /* 2️⃣  magic-string rewrite + inline map */
+  if (
+    moduleInfo.specifier.startsWith('file://') &&
+    moduleInfo.mediaType !== 'Json'
+  ) {
+    source = rewriteAndInlineMap(
+      source,
+      moduleInfo.local,
+    )
+  }
+
+  /* 3️⃣  pass to esbuild.transform() */
+  const result = await transform(source, {
+    loader: mediaTypeToLoader(moduleInfo.mediaType),
+    jsx: 'automatic',
+    jsxImportSource: 'react',
+    sourcefile: moduleInfo.local, // keeps original filename in final map
+    sourcemap: 'external', // or "inline" if Vite prefers
+    logLevel: 'silent',
+  })
+
+  return {
+    code: result.code,
+    map: result.map === '' ? null : result.map,
+  }
+}
+
+/* ───────── pure text-rewriter ───────── */
+
+function rewriteAndInlineMap(source: string, file: string): string {
+  // Quick check to avoid costly parse if no deno-vite directives are present
+  if (!source.includes('@deno-vite-import')) {
+    return source
+  }
+
+  // parse with Babel to support TSX / JSX
+  const ast = babelParse(source, {
+    sourceType: 'module',
+    plugins: [
+      'typescript',
+      'jsx',
+      'classProperties',
+    ],
+    ranges: true,
+    allowReturnOutsideFunction: true,
+  })
+
+  const ms = new MagicString(source)
+  let counter = 0
+  let mutated = false
+
+  // Iterate through top-level comments in the AST
+  for (const comment of ast.comments || []) {
+    if (comment.type !== 'CommentLine') {
+      continue
+    }
+
+    // Check if this comment is at the top level by seeing if it's between top-level nodes
+    // or before the first node
+    const programBody = ast.program.body
+    let isTopLevel = true
+
+    for (const node of programBody) {
+      if (comment.start! >= node.start! && comment.end! <= node.end!) {
+        isTopLevel = false
+        break
+      }
+    }
+
+    if (!isTopLevel) {
+      continue
+    }
+
+    const text = comment.value.trim()
+
+    /* basic: // @deno-vite-import ./foo.css */
+    let m = text.match(/^@deno-vite-import\s+(.+)$/)
+    if (m) {
+      const resolved = resolvePath(dir(file), stripQuotes(m[1]))
+      ms.overwrite(comment.start!, comment.end!, `import '${resolved}';`)
+      mutated = true
+      continue
+    }
+
+    /* advanced: // @deno-vite-import(obj.prop) ./foo.css */
+    m = text.match(/^@deno-vite-import\(([^)]+)\)\s+(.+)$/)
+    if (m) {
+      const target = m[1].trim()
+      const resolved = resolvePath(dir(file), stripQuotes(m[2]))
+      // Always use a temporary binding, then assign — keeps the user's
+      // pre‑declared variable intact in Deno.
+      const tmp = `__dvi_${counter++}`
+      ms.overwrite(
+        comment.start!,
+        comment.end!,
+        `import ${tmp} from '${resolved}';\n${target} = ${tmp};`,
+      )
+      mutated = true
+    }
+  }
+
+  if (!mutated) {
+    return source
+  }
+
+  const map = ms.generateMap({ hires: true })
+  const base64 = btoa(map.toString())
+  return ms.toString() +
+    `\n//# sourceMappingURL=data:application/json;base64,${base64}\n`
+}
+
+function stripQuotes(s: string): string {
+  if (
+    (s.startsWith("'") && s.endsWith("'")) ||
+    (s.startsWith('"') && s.endsWith('"'))
+  ) {
+    return s.slice(1, -1)
+  } else {
+    return s
+  }
+}

--- a/deno.lock
+++ b/deno.lock
@@ -17,18 +17,27 @@
     "jsr:@std/path@1": "1.0.9",
     "jsr:@std/path@^1.0.9": "1.0.9",
     "jsr:@zip-js/zip-js@^2.7.52": "2.7.62",
+    "npm:@babel/parser@^7.27.2": "7.27.2",
+    "npm:@babel/types@^7.27.1": "7.27.1",
     "npm:@prisma/client@*": "6.8.2",
     "npm:@radix-ui/react-slot@^1.2.3": "1.2.3_@types+react@19.1.5_react@19.1.0",
+    "npm:@tailwindcss/vite@^4.1.7": "4.1.7_vite@6.3.5__picomatch@4.0.2__@types+node@22.12.0_@types+node@22.12.0",
     "npm:@types/node@*": "22.12.0",
     "npm:@types/react@*": "19.1.5",
     "npm:@types/react@^19.1.4": "19.1.5",
     "npm:@vitejs/plugin-react@*": "4.4.1_vite@6.3.5__picomatch@4.0.2__@types+node@22.12.0_@babel+core@7.27.1_@types+node@22.12.0",
     "npm:@vitejs/plugin-react@4.4.1": "4.4.1_vite@6.3.5__picomatch@4.0.2__@types+node@22.12.0_@babel+core@7.27.1_@types+node@22.12.0",
+    "npm:acorn-jsx@^5.3.2": "5.3.2_acorn@8.14.1",
+    "npm:acorn-typescript@^1.4.13": "1.4.13_acorn@8.14.1",
+    "npm:acorn@*": "8.14.1",
+    "npm:acorn@^8.14.1": "8.14.1",
     "npm:async-mutex@*": "0.5.0",
     "npm:class-variance-authority@~0.7.1": "0.7.1",
     "npm:clsx@^2.1.1": "2.1.1",
     "npm:esbuild@0.25": "0.25.4",
     "npm:hono@*": "4.7.10",
+    "npm:magic-string@*": "0.30.17",
+    "npm:magic-string@~0.30.17": "0.30.17",
     "npm:react-dom@*": "19.1.0_react@19.1.0",
     "npm:react-dom@^19.1.0": "19.1.0_react@19.1.0",
     "npm:react@*": "19.1.0",
@@ -36,6 +45,7 @@
     "npm:rollup-plugin-node-externals@*": "8.0.0_rollup@4.41.0",
     "npm:rollup-plugin-node-externals@8": "8.0.0_rollup@4.41.0",
     "npm:tailwind-merge@^3.3.0": "3.3.0",
+    "npm:tailwindcss@^4.1.7": "4.1.7",
     "npm:vite@*": "6.3.5_picomatch@4.0.2_@types+node@22.12.0",
     "npm:vite@6.3.5": "6.3.5_picomatch@4.0.2_@types+node@22.12.0",
     "npm:vite@^6.3.5": "6.3.5_picomatch@4.0.2_@types+node@22.12.0"
@@ -248,6 +258,25 @@
         "@babel/helper-validator-identifier"
       ]
     },
+    "@emnapi/core@1.4.3": {
+      "integrity": "sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==",
+      "dependencies": [
+        "@emnapi/wasi-threads",
+        "tslib"
+      ]
+    },
+    "@emnapi/runtime@1.4.3": {
+      "integrity": "sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@emnapi/wasi-threads@1.0.2": {
+      "integrity": "sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
     "@esbuild/aix-ppc64@0.25.4": {
       "integrity": "sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==",
       "os": ["aix"],
@@ -373,6 +402,12 @@
       "os": ["win32"],
       "cpu": ["x64"]
     },
+    "@isaacs/fs-minipass@4.0.1": {
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dependencies": [
+        "minipass"
+      ]
+    },
     "@jridgewell/gen-mapping@0.3.8": {
       "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
       "dependencies": [
@@ -395,6 +430,14 @@
       "dependencies": [
         "@jridgewell/resolve-uri",
         "@jridgewell/sourcemap-codec"
+      ]
+    },
+    "@napi-rs/wasm-runtime@0.2.10": {
+      "integrity": "sha512-bCsCyeZEwVErsGmyPNSzwfwFn4OdxBj0mmv6hOFucB/k81Ojdu68RbZdxYsRQUPc9l6SU5F/cG+bXgWs3oUgsQ==",
+      "dependencies": [
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util"
       ]
     },
     "@prisma/client@6.8.2": {
@@ -522,6 +565,122 @@
       "os": ["win32"],
       "cpu": ["x64"]
     },
+    "@tailwindcss/node@4.1.7": {
+      "integrity": "sha512-9rsOpdY9idRI2NH6CL4wORFY0+Q6fnx9XP9Ju+iq/0wJwGD5IByIgFmwVbyy4ymuyprj8Qh4ErxMKTUL4uNh3g==",
+      "dependencies": [
+        "@ampproject/remapping",
+        "enhanced-resolve",
+        "jiti",
+        "lightningcss",
+        "magic-string",
+        "source-map-js",
+        "tailwindcss"
+      ]
+    },
+    "@tailwindcss/oxide-android-arm64@4.1.7": {
+      "integrity": "sha512-IWA410JZ8fF7kACus6BrUwY2Z1t1hm0+ZWNEzykKmMNM09wQooOcN/VXr0p/WJdtHZ90PvJf2AIBS/Ceqx1emg==",
+      "os": ["android"],
+      "cpu": ["arm64"]
+    },
+    "@tailwindcss/oxide-darwin-arm64@4.1.7": {
+      "integrity": "sha512-81jUw9To7fimGGkuJ2W5h3/oGonTOZKZ8C2ghm/TTxbwvfSiFSDPd6/A/KE2N7Jp4mv3Ps9OFqg2fEKgZFfsvg==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@tailwindcss/oxide-darwin-x64@4.1.7": {
+      "integrity": "sha512-q77rWjEyGHV4PdDBtrzO0tgBBPlQWKY7wZK0cUok/HaGgbNKecegNxCGikuPJn5wFAlIywC3v+WMBt0PEBtwGw==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@tailwindcss/oxide-freebsd-x64@4.1.7": {
+      "integrity": "sha512-RfmdbbK6G6ptgF4qqbzoxmH+PKfP4KSVs7SRlTwcbRgBwezJkAO3Qta/7gDy10Q2DcUVkKxFLXUQO6J3CRvBGw==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
+    },
+    "@tailwindcss/oxide-linux-arm-gnueabihf@4.1.7": {
+      "integrity": "sha512-OZqsGvpwOa13lVd1z6JVwQXadEobmesxQ4AxhrwRiPuE04quvZHWn/LnihMg7/XkN+dTioXp/VMu/p6A5eZP3g==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@tailwindcss/oxide-linux-arm64-gnu@4.1.7": {
+      "integrity": "sha512-voMvBTnJSfKecJxGkoeAyW/2XRToLZ227LxswLAwKY7YslG/Xkw9/tJNH+3IVh5bdYzYE7DfiaPbRkSHFxY1xA==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@tailwindcss/oxide-linux-arm64-musl@4.1.7": {
+      "integrity": "sha512-PjGuNNmJeKHnP58M7XyjJyla8LPo+RmwHQpBI+W/OxqrwojyuCQ+GUtygu7jUqTEexejZHr/z3nBc/gTiXBj4A==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@tailwindcss/oxide-linux-x64-gnu@4.1.7": {
+      "integrity": "sha512-HMs+Va+ZR3gC3mLZE00gXxtBo3JoSQxtu9lobbZd+DmfkIxR54NO7Z+UQNPsa0P/ITn1TevtFxXTpsRU7qEvWg==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@tailwindcss/oxide-linux-x64-musl@4.1.7": {
+      "integrity": "sha512-MHZ6jyNlutdHH8rd+YTdr3QbXrHXqwIhHw9e7yXEBcQdluGwhpQY2Eku8UZK6ReLaWtQ4gijIv5QoM5eE+qlsA==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@tailwindcss/oxide-wasm32-wasi@4.1.7": {
+      "integrity": "sha512-ANaSKt74ZRzE2TvJmUcbFQ8zS201cIPxUDm5qez5rLEwWkie2SkGtA4P+GPTj+u8N6JbPrC8MtY8RmJA35Oo+A==",
+      "dependencies": [
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@emnapi/wasi-threads",
+        "@napi-rs/wasm-runtime",
+        "@tybys/wasm-util",
+        "tslib"
+      ],
+      "cpu": ["wasm32"]
+    },
+    "@tailwindcss/oxide-win32-arm64-msvc@4.1.7": {
+      "integrity": "sha512-HUiSiXQ9gLJBAPCMVRk2RT1ZrBjto7WvqsPBwUrNK2BcdSxMnk19h4pjZjI7zgPhDxlAbJSumTC4ljeA9y0tEw==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@tailwindcss/oxide-win32-x64-msvc@4.1.7": {
+      "integrity": "sha512-rYHGmvoHiLJ8hWucSfSOEmdCBIGZIq7SpkPRSqLsH2Ab2YUNgKeAPT1Fi2cx3+hnYOrAb0jp9cRyode3bBW4mQ==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
+    "@tailwindcss/oxide@4.1.7": {
+      "integrity": "sha512-5SF95Ctm9DFiUyjUPnDGkoKItPX/k+xifcQhcqX5RA85m50jw1pT/KzjdvlqxRja45Y52nR4MR9fD1JYd7f8NQ==",
+      "dependencies": [
+        "detect-libc",
+        "tar"
+      ],
+      "optionalDependencies": [
+        "@tailwindcss/oxide-android-arm64",
+        "@tailwindcss/oxide-darwin-arm64",
+        "@tailwindcss/oxide-darwin-x64",
+        "@tailwindcss/oxide-freebsd-x64",
+        "@tailwindcss/oxide-linux-arm-gnueabihf",
+        "@tailwindcss/oxide-linux-arm64-gnu",
+        "@tailwindcss/oxide-linux-arm64-musl",
+        "@tailwindcss/oxide-linux-x64-gnu",
+        "@tailwindcss/oxide-linux-x64-musl",
+        "@tailwindcss/oxide-wasm32-wasi",
+        "@tailwindcss/oxide-win32-arm64-msvc",
+        "@tailwindcss/oxide-win32-x64-msvc"
+      ],
+      "scripts": true
+    },
+    "@tailwindcss/vite@4.1.7_vite@6.3.5__picomatch@4.0.2__@types+node@22.12.0_@types+node@22.12.0": {
+      "integrity": "sha512-tYa2fO3zDe41I7WqijyVbRd8oWT0aEID1Eokz5hMT6wShLIHj3yvwj9XbfuloHP9glZ6H+aG2AN/+ZrxJ1Y5RQ==",
+      "dependencies": [
+        "@tailwindcss/node",
+        "@tailwindcss/oxide",
+        "tailwindcss",
+        "vite@6.3.5_picomatch@4.0.2_@types+node@22.12.0"
+      ]
+    },
+    "@tybys/wasm-util@0.9.0": {
+      "integrity": "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
     "@types/babel__core@7.20.5": {
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dependencies": [
@@ -577,6 +736,22 @@
         "vite@6.3.5_picomatch@4.0.2_@types+node@22.12.0"
       ]
     },
+    "acorn-jsx@5.3.2_acorn@8.14.1": {
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dependencies": [
+        "acorn"
+      ]
+    },
+    "acorn-typescript@1.4.13_acorn@8.14.1": {
+      "integrity": "sha512-xsc9Xv0xlVfwp2o7sQ+GCQ1PgbkdcpWdTzrwXxO3xDMTAywVS3oXVOcOHuRjAPkS4P9b+yc/qNF15460v+jp4Q==",
+      "dependencies": [
+        "acorn"
+      ]
+    },
+    "acorn@8.14.1": {
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "bin": true
+    },
     "async-mutex@0.5.0": {
       "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
       "dependencies": [
@@ -595,6 +770,9 @@
     },
     "caniuse-lite@1.0.30001718": {
       "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw=="
+    },
+    "chownr@3.0.0": {
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="
     },
     "class-variance-authority@0.7.1": {
       "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
@@ -617,8 +795,18 @@
         "ms"
       ]
     },
+    "detect-libc@2.0.4": {
+      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA=="
+    },
     "electron-to-chromium@1.5.157": {
       "integrity": "sha512-/0ybgsQd1muo8QlnuTpKwtl0oX5YMlUGbm8xyqgDU00motRkKFFbUJySAQBWcY79rVqNLWIWa87BGVGClwAB2w=="
+    },
+    "enhanced-resolve@5.18.1": {
+      "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
+      "dependencies": [
+        "graceful-fs",
+        "tapable"
+      ]
     },
     "esbuild@0.25.4": {
       "integrity": "sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==",
@@ -675,8 +863,15 @@
     "globals@11.12.0": {
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
     },
+    "graceful-fs@4.2.11": {
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+    },
     "hono@4.7.10": {
       "integrity": "sha512-QkACju9MiN59CKSY5JsGZCYmPZkA6sIW6OFCUp7qDjZu6S6KHtJHhAc9Uy9mV9F8PJ1/HQ3ybZF2yjCa/73fvQ=="
+    },
+    "jiti@2.4.2": {
+      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "bin": true
     },
     "js-tokens@4.0.0": {
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
@@ -689,11 +884,98 @@
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "bin": true
     },
+    "lightningcss-darwin-arm64@1.30.1": {
+      "integrity": "sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "lightningcss-darwin-x64@1.30.1": {
+      "integrity": "sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "lightningcss-freebsd-x64@1.30.1": {
+      "integrity": "sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
+    },
+    "lightningcss-linux-arm-gnueabihf@1.30.1": {
+      "integrity": "sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "lightningcss-linux-arm64-gnu@1.30.1": {
+      "integrity": "sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "lightningcss-linux-arm64-musl@1.30.1": {
+      "integrity": "sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "lightningcss-linux-x64-gnu@1.30.1": {
+      "integrity": "sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "lightningcss-linux-x64-musl@1.30.1": {
+      "integrity": "sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "lightningcss-win32-arm64-msvc@1.30.1": {
+      "integrity": "sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "lightningcss-win32-x64-msvc@1.30.1": {
+      "integrity": "sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
+    "lightningcss@1.30.1": {
+      "integrity": "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==",
+      "dependencies": [
+        "detect-libc"
+      ],
+      "optionalDependencies": [
+        "lightningcss-darwin-arm64",
+        "lightningcss-darwin-x64",
+        "lightningcss-freebsd-x64",
+        "lightningcss-linux-arm-gnueabihf",
+        "lightningcss-linux-arm64-gnu",
+        "lightningcss-linux-arm64-musl",
+        "lightningcss-linux-x64-gnu",
+        "lightningcss-linux-x64-musl",
+        "lightningcss-win32-arm64-msvc",
+        "lightningcss-win32-x64-msvc"
+      ]
+    },
     "lru-cache@5.1.1": {
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dependencies": [
-        "yallist"
+        "yallist@3.1.1"
       ]
+    },
+    "magic-string@0.30.17": {
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "dependencies": [
+        "@jridgewell/sourcemap-codec"
+      ]
+    },
+    "minipass@7.1.2": {
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="
+    },
+    "minizlib@3.0.2": {
+      "integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
+      "dependencies": [
+        "minipass"
+      ]
+    },
+    "mkdirp@3.0.1": {
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "bin": true
     },
     "ms@2.1.3": {
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
@@ -781,6 +1063,23 @@
     "tailwind-merge@3.3.0": {
       "integrity": "sha512-fyW/pEfcQSiigd5SNn0nApUOxx0zB/dm6UDU/rEwc2c3sX2smWUNbapHv+QRqLGVp9GWX3THIa7MUGPo+YkDzQ=="
     },
+    "tailwindcss@4.1.7": {
+      "integrity": "sha512-kr1o/ErIdNhTz8uzAYL7TpaUuzKIE6QPQ4qmSdxnoX/lo+5wmUHQA6h3L5yIqEImSRnAAURDirLu/BgiXGPAhg=="
+    },
+    "tapable@2.2.2": {
+      "integrity": "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg=="
+    },
+    "tar@7.4.3": {
+      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
+      "dependencies": [
+        "@isaacs/fs-minipass",
+        "chownr",
+        "minipass",
+        "minizlib",
+        "mkdirp",
+        "yallist@5.0.0"
+      ]
+    },
     "tinyglobby@0.2.13_picomatch@4.0.2": {
       "integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
       "dependencies": [
@@ -839,6 +1138,9 @@
     },
     "yallist@3.1.1": {
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+    },
+    "yallist@5.0.0": {
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="
     }
   },
   "remote": {
@@ -853,7 +1155,13 @@
       "deno-vite-plus": {
         "packageJson": {
           "dependencies": [
+            "npm:@babel/parser@^7.27.2",
+            "npm:@babel/types@^7.27.1",
+            "npm:acorn-jsx@^5.3.2",
+            "npm:acorn-typescript@^1.4.13",
+            "npm:acorn@^8.14.1",
             "npm:esbuild@0.25",
+            "npm:magic-string@~0.30.17",
             "npm:react-dom@^19.1.0",
             "npm:react@^19.1.0",
             "npm:rollup-plugin-node-externals@8",
@@ -866,7 +1174,13 @@
           "npm:react-dom@^19.1.0",
           "npm:react@^19.1.0",
           "npm:vite@^6.3.5"
-        ]
+        ],
+        "packageJson": {
+          "dependencies": [
+            "npm:@tailwindcss/vite@^4.1.7",
+            "npm:tailwindcss@^4.1.7"
+          ]
+        }
       }
     }
   }

--- a/example-basic/package.json
+++ b/example-basic/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@tailwindcss/vite": "^4.1.7",
+    "tailwindcss": "^4.1.7"
+  }
+}

--- a/example-basic/src/App.tsx
+++ b/example-basic/src/App.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react'
 import { Button } from 'jsr:@isofucius/deno-shadcn-ui/default/ui/button'
 
+// @deno-vite-import ./globals.css
+
 function App() {
   const [count, setCount] = useState(0)
 

--- a/example-basic/src/globals.css
+++ b/example-basic/src/globals.css
@@ -1,0 +1,6 @@
+@import 'tailwindcss';
+
+/* Set a background color to verify Tailwind is working */
+body {
+  @apply bg-slate-100;
+}

--- a/example-basic/vite.config.ts
+++ b/example-basic/vite.config.ts
@@ -1,12 +1,13 @@
 import { defineConfig } from 'vite'
 import react from 'npm:@vitejs/plugin-react@4.4.1'
+import tailwindcss from '@tailwindcss/vite'
 import fasterDeno from '@pea2/faster-deno-vite'
 
 // Default config for development
 export default defineConfig({
   plugins: [
-    // For development, we use the default dev: true option
     fasterDeno(),
     react(),
+    tailwindcss(),
   ],
 })


### PR DESCRIPTION
## Summary
- Add vite-load-hook plugin for handling Deno-specific imports during development
- Improve deno-resolver to better handle JSR and npm: imports with proper transformation
- Add package.json files to enable npm package usage in examples

🤖 Generated with [Claude Code](https://claude.ai/code)