### PR TITLE
Add support for @deno-source in CSS for Tailwind

### DIFF
--- a/deno-vite-plus/index.ts
+++ b/deno-vite-plus/index.ts
@@ -1,5 +1,6 @@
 import type { Plugin } from 'vite'
 import viteDenoResolver from './plugins/vite-deno-resolver.ts'
+import { viteDenoTailwindSource } from './plugins/vite-deno-tailwind-source.ts'
 import nodeExternals from 'npm:rollup-plugin-node-externals'
 
 /**
@@ -23,3 +24,8 @@ export default function fasterDeno(): Plugin[] {
     }),
   ]
 }
+
+/**
+ * Export individual plugins for more granular control
+ */
+export { viteDenoResolver, viteDenoTailwindSource }

--- a/deno-vite-plus/plugins/vite-deno-resolver.ts
+++ b/deno-vite-plus/plugins/vite-deno-resolver.ts
@@ -4,7 +4,6 @@ import { extname } from 'jsr:@std/path'
 import type { Plugin } from 'vite'
 import { DenoEnv } from '@/lib/deno-env.ts'
 import { DenoResolver } from '@/lib/deno-resolver.ts'
-import process from 'node:process'
 import { loadAndRewrite } from './vite-load-hook.ts'
 
 export function toDenoSpecifier(specifier: string): string {
@@ -66,7 +65,7 @@ export default function viteDenoResolver(): Plugin {
       isSSR = env.isSsrBuild || false
 
       // Initialize resolver with the correct root directory
-      root = config.root || process.cwd()
+      root = config.root || Deno.cwd()
       resolver = new DenoResolver(new DenoEnv(root))
 
       // Ensure correct resolve conditions for browser vs SSR

--- a/deno-vite-plus/plugins/vite-deno-tailwind-source.ts
+++ b/deno-vite-plus/plugins/vite-deno-tailwind-source.ts
@@ -1,0 +1,140 @@
+import type { Plugin } from 'vite'
+import { DenoEnv } from '@/lib/deno-env.ts'
+import { DenoResolver } from '@/lib/deno-resolver.ts'
+import { dirname, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+/**
+ * Vite plugin that transforms @deno-source directives to @source directives
+ * for Tailwind CSS by analyzing the Deno dependency graph.
+ */
+export function viteDenoTailwindSource(): Plugin {
+  let resolver: DenoResolver
+  let root: string
+
+  return {
+    name: 'vite-deno-tailwind-source',
+    enforce: 'pre', // Must run before @tailwindcss/vite
+
+    async config(config, _env) {
+      // Initialize resolver with the correct root directory
+      root = config.root || Deno.cwd()
+      resolver = new DenoResolver(new DenoEnv(root))
+
+      return config
+    },
+
+    async transform(css, id) {
+      // Only process CSS files
+      if (!id.endsWith('.css')) {
+        return null
+      }
+
+      // Find all @deno-source directives
+      const matches = [...css.matchAll(/@deno-source\s+["']([^"']+)["'];?/g)]
+      if (matches.length === 0) {
+        return null
+      }
+
+      const extraSources = new Set<string>()
+
+      for (const [, rawSpecifier] of matches) {
+        console.log('Found one deno source', rawSpecifier)
+
+        // Resolve relative paths to absolute URLs
+        const baseDir = dirname(id)
+        const absolutePath = resolve(baseDir, rawSpecifier)
+
+        // Scan for JSX/TSX files in the specified directory
+        const jsxTsxFiles = await scanForJsxTsxFiles(absolutePath)
+        console.log(
+          `Found ${jsxTsxFiles.length} JSX/TSX files in ${absolutePath}`,
+        )
+
+        // Collect dependencies for each JSX/TSX file
+        for (const file of jsxTsxFiles) {
+          const fileUrl = pathToFileURL(file).href
+          console.log(`Processing file: ${file} -> ${fileUrl}`)
+
+          try {
+            const deps = await resolver.collectDeps(fileUrl)
+            console.log(`Found ${deps.length} dependencies for ${file}`)
+
+            // Filter and add valid source files
+            for (const dep of deps) {
+              // Get module info to check media type
+              try {
+                const module = resolver.retrieveModule(dep)
+                if ('error' in module || module.kind !== 'esm') {
+                  continue
+                }
+
+                // Check if this is a scannable file based on media type
+                if (module.mediaType === 'JSX' || module.mediaType === 'TSX') {
+                  extraSources.add(module.local)
+                }
+              } catch (_error) {
+                // Skip modules that can't be retrieved
+              }
+            }
+          } catch (error) {
+            console.error(`Failed to collect deps for ${file}:`, error)
+          }
+        }
+      }
+
+      // Build the replacement CSS
+      const tailwindSources = Array.from(extraSources)
+        .map((p) => `@source "${normalizePathForTailwind(p)}";`)
+        .join('\n')
+
+      console.log(`Generated ${extraSources.size} @source directives`)
+
+      // Remove @deno-source directives and append @source directives
+      const withoutDenoSource = css.replace(
+        /@deno-source\s+["'][^"']+["'];?/g,
+        '',
+      ).trim()
+      const nextCss = withoutDenoSource + '\n' + tailwindSources + '\n'
+
+      console.log('Transformed CSS:', nextCss)
+
+      return {
+        code: nextCss,
+        map: null,
+      }
+    },
+  }
+}
+
+/**
+ * Scan directory for JSX/TSX files
+ */
+async function scanForJsxTsxFiles(dir: string): Promise<string[]> {
+  const files: string[] = []
+
+  try {
+    for await (const entry of Deno.readDir(dir)) {
+      const fullPath = resolve(dir, entry.name)
+
+      if (entry.isDirectory) {
+        // Recursively scan subdirectories
+        const subFiles = await scanForJsxTsxFiles(fullPath)
+        files.push(...subFiles)
+      } else if (entry.isFile && /\.(jsx|tsx)$/.test(entry.name)) {
+        files.push(fullPath)
+      }
+    }
+  } catch (error) {
+    console.warn(`Failed to scan directory ${dir}:`, error)
+  }
+
+  return files
+}
+
+/**
+ * Normalize paths for Tailwind (convert to forward slashes on Windows)
+ */
+function normalizePathForTailwind(path: string): string {
+  return path.replace(/\\/g, '/')
+}

--- a/example-basic/src/globals.css
+++ b/example-basic/src/globals.css
@@ -1,6 +1,124 @@
 @import 'tailwindcss';
 
-/* Set a background color to verify Tailwind is working */
-body {
-  @apply bg-slate-100;
+@deno-source '.';
+
+@custom-variant dark (&:is(.dark *));
+
+:root {
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(0.577 0.245 27.325);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.704);
+  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+  --radius: 0.625rem;
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.145 0 0);
+  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0.922 0 0);
+  --sidebar-ring: oklch(0.708 0 0);
+}
+
+.dark {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.145 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.145 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.985 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.396 0.141 25.723);
+  --destructive-foreground: oklch(0.637 0.237 25.331);
+  --border: oklch(0.269 0 0);
+  --input: oklch(0.269 0 0);
+  --ring: oklch(0.439 0 0);
+  --chart-1: oklch(0.488 0.243 264.376);
+  --chart-2: oklch(0.696 0.17 162.48);
+  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
+  --sidebar: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(0.269 0 0);
+  --sidebar-ring: oklch(0.439 0 0);
+}
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+}
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
 }

--- a/example-basic/vite.config.ts
+++ b/example-basic/vite.config.ts
@@ -2,12 +2,14 @@ import { defineConfig } from 'vite'
 import react from 'npm:@vitejs/plugin-react@4.4.1'
 import tailwindcss from '@tailwindcss/vite'
 import fasterDeno from '@pea2/faster-deno-vite'
+import { viteDenoTailwindSource } from '@pea2/faster-deno-vite'
 
 // Default config for development
 export default defineConfig({
   plugins: [
     fasterDeno(),
     react(),
+    viteDenoTailwindSource(),
     tailwindcss(),
   ],
 })


### PR DESCRIPTION
## Summary
- Add vite-deno-tailwind-source plugin that transforms `@deno-source` directives into multiple `@source` directives
- Analyze Deno's dependency graph to include only JSX/TSX files that are actually imported
- Enable precise Tailwind CSS scanning for optimal CSS generation

## Implementation
- New plugin runs before Tailwind's Vite plugin with `enforce: 'pre'`
- Scans directories for JSX/TSX files when encountering `@deno-source`
- Uses DenoResolver's new `collectDeps` method to traverse dependency graph
- Filters modules by MediaType to include only scannable files (JSX/TSX)
- Transforms CSS to replace `@deno-source` with specific `@source` directives

## Example
Input CSS:
```css
@import "tailwindcss";
@deno-source ".";
```

Output CSS:
```css
@import "tailwindcss";
@source "/path/to/App.tsx";
@source "/path/to/main.tsx";
@source "/path/to/entry-server.tsx";
```

Closes AXE-134

🤖 Generated with [Claude Code](https://claude.ai/code)