### PR TITLE
Prepare deno-vite-plus for JSR publishing

### DIFF
--- a/deno-vite-plus/deno.json
+++ b/deno-vite-plus/deno.json
@@ -1,13 +1,32 @@
 {
-  "name": "@pea2/faster-deno-vite",
+  "name": "@isofucius/deno-vite-plus",
+  "version": "0.1.0",
   "exports": {
-    ".": "./index.ts",
-    "./faster-deno-css": "./faster-deno-css.ts"
+    ".": "./index.ts"
+  },
+  "publish": {
+    "include": [
+      "README.md",
+      "LICENSE",
+      "deno.json",
+      "index.ts",
+      "lib/deno-env.ts",
+      "lib/deno-resolver.ts",
+      "lib/types.ts",
+      "plugins/vite-deno-resolver.ts",
+      "plugins/vite-load-hook.ts",
+      "plugins/vite-deno-tailwind-source.ts"
+    ]
+  },
+  "compilerOptions": {
+    "lib": [
+      "deno.window"
+    ]
   },
   "imports": {
     "@/lib/": "./lib/",
-    "@/lib/utils.ts": "./lib/utils.ts",
-    "@/lib/resolver.ts": "./lib/resolver.ts"
+    "@std/assert": "jsr:@std/assert@^1.0.13",
+    "@std/path": "jsr:@std/path@^1.0.9"
   },
   "tasks": {
     "test": "deno test -A",

--- a/deno-vite-plus/index.ts
+++ b/deno-vite-plus/index.ts
@@ -1,7 +1,7 @@
 import type { Plugin } from 'vite'
 import viteDenoResolver from './plugins/vite-deno-resolver.ts'
 import { viteDenoTailwindSource } from './plugins/vite-deno-tailwind-source.ts'
-import nodeExternals from 'npm:rollup-plugin-node-externals'
+import nodeExternals from 'rollup-plugin-node-externals'
 
 /**
  * Main plugin factory for deno-vite-plus

--- a/deno-vite-plus/lib/deno-env.ts
+++ b/deno-vite-plus/lib/deno-env.ts
@@ -1,5 +1,5 @@
-import { assert } from 'jsr:@std/assert'
-import { Mutex } from 'npm:async-mutex'
+import { assert } from '@std/assert'
+import { Mutex } from 'async-mutex'
 import type { DenoInfoJsonV1 } from './types.ts'
 
 async function run(cmd: string[], cwd: string) {

--- a/deno-vite-plus/package.json
+++ b/deno-vite-plus/package.json
@@ -6,6 +6,7 @@
     "acorn": "^8.14.1",
     "acorn-jsx": "^5.3.2",
     "acorn-typescript": "^1.4.13",
+    "async-mutex": "^0.5.0",
     "magic-string": "^0.30.17",
     "postcss-import": "^16.1.0",
     "react": "^19.1.0",

--- a/deno-vite-plus/plugins/vite-deno-resolver.ts
+++ b/deno-vite-plus/plugins/vite-deno-resolver.ts
@@ -1,6 +1,4 @@
-/// <reference lib="deno.window" />
-
-import { extname } from 'jsr:@std/path'
+import { extname } from '@std/path'
 import type { Plugin } from 'vite'
 import { DenoEnv } from '@/lib/deno-env.ts'
 import { DenoResolver } from '@/lib/deno-resolver.ts'

--- a/deno-vite-plus/plugins/vite-deno-tailwind-source.ts
+++ b/deno-vite-plus/plugins/vite-deno-tailwind-source.ts
@@ -1,7 +1,7 @@
 import type { Plugin } from 'vite'
 import { DenoEnv } from '@/lib/deno-env.ts'
 import { DenoResolver } from '@/lib/deno-resolver.ts'
-import { dirname, resolve, toFileUrl } from 'jsr:@std/path'
+import { dirname, resolve, toFileUrl } from '@std/path'
 
 /**
  * Vite plugin that transforms @deno-source directives to @source directives

--- a/deno-vite-plus/plugins/vite-load-hook.ts
+++ b/deno-vite-plus/plugins/vite-load-hook.ts
@@ -1,8 +1,8 @@
 // vite_load_hook.ts --------------------------------------------------------
-import { dirname as dir, join, resolve as resolvePath } from 'jsr:@std/path'
+import { dirname as dir, join, resolve as resolvePath } from '@std/path'
 import { type Loader, transform } from 'esbuild'
 import { parse as babelParse } from '@babel/parser'
-import MagicString from 'npm:magic-string'
+import MagicString from 'magic-string'
 
 import type { DenoMediaType, ResolvedInfo } from '../lib/types.ts'
 

--- a/deno.lock
+++ b/deno.lock
@@ -8,6 +8,7 @@
     "jsr:@isofucius/deno-shadcn-ui@*": "0.0.5",
     "jsr:@isofucius/deno-shadcn-ui@0.0.5": "0.0.5",
     "jsr:@std/assert@*": "1.0.13",
+    "jsr:@std/assert@^1.0.13": "1.0.13",
     "jsr:@std/async@1": "1.0.13",
     "jsr:@std/fmt@1.0.3": "1.0.3",
     "jsr:@std/fs@*": "1.0.17",
@@ -56,6 +57,7 @@
     "npm:acorn-typescript@^1.4.13": "1.4.13_acorn@8.14.1",
     "npm:acorn@^8.14.1": "8.14.1",
     "npm:async-mutex@*": "0.5.0",
+    "npm:async-mutex@0.5": "0.5.0",
     "npm:class-variance-authority@~0.7.1": "0.7.1",
     "npm:clsx@^2.1.1": "2.1.1",
     "npm:cmdk@^1.1.1": "1.1.1_react@19.1.0_react-dom@19.1.0__react@19.1.0_@types+react@19.1.5",
@@ -2505,6 +2507,10 @@
     ],
     "members": {
       "deno-vite-plus": {
+        "dependencies": [
+          "jsr:@std/assert@^1.0.13",
+          "jsr:@std/path@^1.0.9"
+        ],
         "packageJson": {
           "dependencies": [
             "npm:@babel/parser@^7.27.2",
@@ -2512,6 +2518,7 @@
             "npm:acorn-jsx@^5.3.2",
             "npm:acorn-typescript@^1.4.13",
             "npm:acorn@^8.14.1",
+            "npm:async-mutex@0.5",
             "npm:esbuild@0.25",
             "npm:magic-string@~0.30.17",
             "npm:postcss-import@^16.1.0",

--- a/example-basic/vite.config.ts
+++ b/example-basic/vite.config.ts
@@ -1,8 +1,8 @@
 import { defineConfig } from 'vite'
 import react from 'npm:@vitejs/plugin-react@4.4.1'
 import tailwindcss from '@tailwindcss/vite'
-import fasterDeno from '@pea2/faster-deno-vite'
-import { viteDenoTailwindSource } from '@pea2/faster-deno-vite'
+import fasterDeno from '@isofucius/deno-vite-plus'
+import { viteDenoTailwindSource } from '@isofucius/deno-vite-plus'
 
 // Default config for development
 export default defineConfig({


### PR DESCRIPTION
## Summary
- Update package name to @isofucius/deno-vite-plus for JSR publishing
- Add proper configuration for `deno publish` command
- Remove jsr:/npm: prefixes to use import map for version locking

## Changes
- Updated package name from @pea2/faster-deno-vite to @isofucius/deno-vite-plus
- Added version 0.1.0 to deno.json
- Added publish configuration with explicit file includes
- Removed jsr:/npm: prefixes from imports to use import map
- Added compilerOptions for lib: ["deno.window"] to replace triple slash directive
- Updated example-basic imports to use new package name

## Test plan
- [x] All tests pass
- [x] Pre-commit hooks pass
- [ ] Run `deno publish --dry-run` to verify configuration
- [ ] Publish to JSR after merge

Related to Linear issue AXE-138

🤖 Generated with [Claude Code](https://claude.ai/code)