### PR TITLE
feat: enhance Deno Vite plugin with SSR, remote modules, and node support

### DIFF
--- a/deno-vite-plus/.vscode/settings.json
+++ b/deno-vite-plus/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "deno.enable": true,
+  "typescript.validate.enable": false,
+  "javascript.validate.enable": false,
+  "css.validate": false,
+  "editor.tabSize": 2,
+  "editor.insertSpaces": true
+}

--- a/deno-vite-plus/deno.json
+++ b/deno-vite-plus/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@isofucius/deno-vite-plus",
-  "version": "0.1.0",
+  "version": "0.1.8",
   "exports": {
     ".": "./index.ts"
   },


### PR DESCRIPTION
## Summary
- Squash merge of 8 debug commits from production testing via JSR releases (v0.1.0 → v0.1.8)
- Implements critical fixes for SSR, remote module handling, and node support

## Changes
- ✨ Add support for `virtual:` and `node:` prefixed imports
- 🚀 Improve SSR detection and external module filtering for React ecosystem
- 🔄 Replace `.local` cache dependency with own remote file caching system
- 🎨 Enhance Tailwind CSS `@deno-source` for remote modules  
- ⚡ Fix performance regression in file type checking
- 🔥 Remove CI workflow (moved elsewhere)

## Technical Details
- **Virtual modules**: Added to skip list to prevent resolution conflicts
- **Node built-ins**: Properly externalized (e.g., `node:path`, `node:fs`)
- **SSR improvements**: Better detection using `options?.ssr` parameter
- **Remote caching**: Independent cache system via `remoteAssetCache` instead of relying on Deno's `.local`
- **Tailwind integration**: Remote Deno modules now work in `@deno-source` directives

## Testing
These changes have been battle-tested in production through incremental JSR releases.

Fixes #PEA-114

🤖 Generated with [Claude Code](https://claude.ai/code)